### PR TITLE
Update groupId

### DIFF
--- a/examples/demo/pom.xml
+++ b/examples/demo/pom.xml
@@ -26,7 +26,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.github.rcosta358</groupId>
+      <groupId>io.github.liquid-java</groupId>
       <artifactId>liquidjava-api</artifactId>
       <version>0.0.3</version>
     </dependency>


### PR DESCRIPTION
With the new `liquid-java` namespace, we can use the new group id for the API jar.

```xml
<dependency>
	<groupId>io.github.liquid-java</groupId> <!-- instead of io.github.rcosta358 -->
	<artifactId>liquidjava-api</artifactId>
	<version>0.0.3</version>
</dependency>
```
